### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   pdoc:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       - name: "Build the virtual environment for ${{ github.repository }}"
         uses: tschm/cradle/actions/environment@v0.1.75
@@ -16,6 +18,8 @@ jobs:
 
   test:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       - name: "Build the virtual environment for ${{ github.repository }}"
         uses: tschm/cradle/actions/environment@v0.1.75


### PR DESCRIPTION
Potential fix for [https://github.com/tschm/amberdata/security/code-scanning/6](https://github.com/tschm/amberdata/security/code-scanning/6)

To fix the issue, we need to add explicit permissions blocks to the `pdoc` and `test` jobs in the workflow file. These permissions should be limited to the least privileges required for the jobs to function correctly. Based on the context, the `contents: read` permission is likely sufficient for these jobs, as they seem to involve building environments and running tests.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
