### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: "CI"
 
+permissions:
+  contents: read
+
 on:
 - push
 


### PR DESCRIPTION
Potential fix for [https://github.com/tschm/amberdata/security/code-scanning/7](https://github.com/tschm/amberdata/security/code-scanning/7)

To fix the issue, add a `permissions` block to the workflow to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow only builds a virtual environment and runs tests, it likely only requires `contents: read` permissions. This change should be applied at the root level of the workflow to cover all jobs unless specific jobs require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
